### PR TITLE
Calculate metadata properly

### DIFF
--- a/include/time_series_tools/mann_kendall.h
+++ b/include/time_series_tools/mann_kendall.h
@@ -29,6 +29,8 @@ private:
   Result perform_test();
   std::int8_t compute_sign(double lhs, double rhs);
 
+  double calculate_p_value(double z);
+
   std::vector<std::uint32_t> find_ties();
 };
 } // namespace  tst

--- a/include/time_series_tools/mann_kendall.h
+++ b/include/time_series_tools/mann_kendall.h
@@ -30,6 +30,7 @@ private:
   std::int8_t compute_sign(double lhs, double rhs);
 
   double calculate_p_value(double z);
+  double calculate_slope();
 
   std::vector<std::uint32_t> find_ties();
 };

--- a/src/mann_kendall.cpp
+++ b/src/mann_kendall.cpp
@@ -56,8 +56,13 @@ MannKendall::Result MannKendall::perform_test() {
     z_value = (s_value + 1) / std::sqrt(variance);
   }
 
+  double p_value = calculate_p_value(z_value);
+
+  std::cout << "Z value: " << z_value << "\n";
+  std::cout << "Two-tailed probability: " << p_value << "\n";
+
   MannKendall::Result result;
-  result.probability = z_value;
+  result.probability = p_value;
   if (z_value >= (1.0 - _significance)) {
     result.trend = Trend::upward;
   }
@@ -107,4 +112,10 @@ std::vector<std::uint32_t> MannKendall::find_ties() {
   }
 
   return ties_count;
+}
+
+double MannKendall::calculate_p_value(double z) {
+  double phi = 0.5 * (1.0 + std::erf(z / std::sqrt(2.0)));
+  double p_value = 2.0 * (1.0 - phi);
+  return p_value;
 }

--- a/src/mann_kendall.cpp
+++ b/src/mann_kendall.cpp
@@ -58,9 +58,6 @@ MannKendall::Result MannKendall::perform_test() {
 
   double p_value = calculate_p_value(z_value);
 
-  std::cout << "Z value: " << z_value << "\n";
-  std::cout << "Two-tailed probability: " << p_value << "\n";
-
   MannKendall::Result result;
   result.probability = p_value;
   if (z_value >= (1.0 - _significance)) {
@@ -70,6 +67,7 @@ MannKendall::Result MannKendall::perform_test() {
     result.trend = Trend::downward;
   }
 
+  result.slope = calculate_slope();
   return result;
 }
 
@@ -118,4 +116,23 @@ double MannKendall::calculate_p_value(double z) {
   double phi = 0.5 * (1.0 + std::erf(z / std::sqrt(2.0)));
   double p_value = 2.0 * (1.0 - phi);
   return p_value;
+}
+
+// Assumes uniform distribution of data points
+double MannKendall::calculate_slope() {
+  std::vector<double> slopes;
+
+  for (int i = 0; i < _data.size() - 1; i++) {
+    for (int j = i + 1; j < _data.size(); j++) {
+      slopes.push_back((_data[j] - _data[i]) / (j - i));
+    }
+  }
+
+  std::sort(slopes.begin(), slopes.end());
+
+  if (slopes.size() % 2 == 0) {
+    return (slopes[slopes.size() / 2] + slopes[(slopes.size() / 2) - 1]) / 2.0;
+  } else {
+    return slopes[slopes.size() / 2];
+  }
 }

--- a/tests/test_mann_kendall.cpp
+++ b/tests/test_mann_kendall.cpp
@@ -33,3 +33,13 @@ TEST(MannKendallTests, TestNoTrend) {
 
   EXPECT_EQ(result.trend, MannKendall::Trend::no_trend);
 }
+
+TEST(MannKendallTests, TestSlope) {
+  std::vector<double> data = {1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6};
+
+  MannKendall algorithm(.05);
+
+  auto result = algorithm.set_data(data);
+
+  EXPECT_EQ(result.slope, .5);
+}


### PR DESCRIPTION
Fixes  #1 and addresses the misunderstood p value calculation from the original document.